### PR TITLE
Update sidebar statistics to reflect filtered farmlands

### DIFF
--- a/src/components/Layout/Layout.jsx
+++ b/src/components/Layout/Layout.jsx
@@ -78,12 +78,15 @@ const Layout = () => {
     [removeFarmland],
   );
 
+  const filteredFarmlands = filterFarmlandsList();
+
   return (
     <div className={classes.layoutRoot}>
       <aside className={classes.layoutSide}>
         <Side
           onSelect={handlerSelectSide}
           active={location.pathname === "/" ? "dashboard" : "farmlands"}
+          farmlands={filteredFarmlands}
         />
       </aside>
 
@@ -114,7 +117,7 @@ const Layout = () => {
               </Button>
             </div>
             <MobileMenu
-              farmlands={farmlands}
+              farmlands={filteredFarmlands}
               onSearchChange={searchChangeHandler}
               onCreateFarmland={onCreateButtonClickHandler}
               onFitosanitariClick={() => handlerSelectSide("fitosanitari")}
@@ -125,7 +128,7 @@ const Layout = () => {
         <section className={classes.layoutContent}>
           <Outlet
             context={{
-              farmlands: filterFarmlandsList(),
+              farmlands: filteredFarmlands,
               onClick: handlerFarmlandOnClick,
               onClose: () => navigate("/"),
               onDelete: removeFarmlandHandler,

--- a/src/components/Side/Side.jsx
+++ b/src/components/Side/Side.jsx
@@ -9,13 +9,24 @@ import GridViewIcon from "@mui/icons-material/GridView";
 import StraightenIcon from "@mui/icons-material/Straighten";
 import HubIcon from "@mui/icons-material/Hub";
 
-const Side = ({ onSelect, active }) => {
+const Side = ({ onSelect, active, farmlands = [] }) => {
   const [itemActive, setItemActive] = useState(active);
 
   const handlerClick = (target) => {
     onSelect(target);
     setItemActive(target);
   };
+
+  const numberfields = farmlands ? farmlands.length : 0;
+  const area = farmlands
+    ? farmlands.reduce((prevVal, currVal) => prevVal + (currVal.area || 0), 0)
+    : 0;
+  const perimeter = farmlands
+    ? farmlands.reduce(
+        (prevVal, currVal) => prevVal + (currVal.perimeter || 0),
+        0,
+      )
+    : 0;
 
   return (
     <div className={classes.sideContainer}>
@@ -31,7 +42,7 @@ const Side = ({ onSelect, active }) => {
           </div>
           <div className={classes.statText}>
             <div className={classes.statLabel}>NUMERO DI CAMPI</div>
-            <div className={classes.statValue}>3</div>
+            <div className={classes.statValue}>{numberfields}</div>
           </div>
         </div>
 
@@ -41,7 +52,7 @@ const Side = ({ onSelect, active }) => {
           </div>
           <div className={classes.statText}>
             <div className={classes.statLabel}>AREA TOTALE</div>
-            <div className={classes.statValue}>469m²</div>
+            <div className={classes.statValue}>{area}m²</div>
           </div>
         </div>
 
@@ -51,7 +62,7 @@ const Side = ({ onSelect, active }) => {
           </div>
           <div className={classes.statText}>
             <div className={classes.statLabel}>PERIMETRO</div>
-            <div className={classes.statValue}>124m</div>
+            <div className={classes.statValue}>{perimeter}m</div>
           </div>
         </div>
       </div>

--- a/src/components/Side/Side.test.jsx
+++ b/src/components/Side/Side.test.jsx
@@ -1,0 +1,38 @@
+import { render, screen } from "@testing-library/react";
+import Side from "./Side";
+import { describe, it, expect, vi } from "vitest";
+import React from "react";
+
+// Mock the SideItem component
+vi.mock("./SideItem", () => ({
+  default: ({ label }) => <div>{label}</div>,
+}));
+
+describe("Side Component", () => {
+  const mockOnSelect = vi.fn();
+  const farmlands = [
+    { id: 1, area: 100, perimeter: 40 },
+    { id: 2, area: 200, perimeter: 60 },
+  ];
+
+  it("renders correctly with provided farmlands statistics", () => {
+    render(<Side onSelect={mockOnSelect} active="dashboard" farmlands={farmlands} />);
+
+    expect(screen.getByText("NUMERO DI CAMPI")).toBeDefined();
+    expect(screen.getByText("2")).toBeDefined();
+
+    expect(screen.getByText("AREA TOTALE")).toBeDefined();
+    expect(screen.getByText("300m²")).toBeDefined();
+
+    expect(screen.getByText("PERIMETRO")).toBeDefined();
+    expect(screen.getByText("100m")).toBeDefined();
+  });
+
+  it("renders zero values when no farmlands are provided", () => {
+    render(<Side onSelect={mockOnSelect} active="dashboard" farmlands={[]} />);
+
+    expect(screen.getByText("0")).toBeDefined();
+    expect(screen.getByText("0m²")).toBeDefined();
+    expect(screen.getByText("0m")).toBeDefined();
+  });
+});


### PR DESCRIPTION
This PR fixes an issue where the sidebar statistics (Number of fields, Total Area, and Perimeter) were hardcoded and did not reflect the actual data or the applied filters.

Key changes:
1.  **Layout Integration**: In `Layout.jsx`, the `filterFarmlandsList()` result is now stored in a variable and passed to both `Side` and `MobileMenu` components. This ensures that when a user searches for a specific field, the summary statistics in the sidebar and mobile drawer update accordingly.
2.  **Dynamic Statistics**: The `Side` component now accepts a `farmlands` prop and calculates the summary values using the same logic as the `MobileMenu`.
3.  **Testing**: Added `src/components/Side/Side.test.jsx` to ensure that the statistics are calculated correctly and handled edge cases (like empty lists).

All tests passed successfully.

---
*PR created automatically by Jules for task [1688418767153154030](https://jules.google.com/task/1688418767153154030) started by @adekro*