### PR TITLE
Refactor Header and Sidebar Layout

### DIFF
--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -3,9 +3,6 @@ import styles from "./Header.module.scss";
 const Header = ({ children }) => {
   return (
     <header className={styles.Header}>
-      <a href="#default" className={styles.logo}>
-        <img src="/logolabel.png" alt="Logo of Agricola app" />
-      </a>
       {children}
       {/* <div className={styles["header-right"]}>
         <a className={styles.active} href="#home">

--- a/src/components/Header/Header.module.scss
+++ b/src/components/Header/Header.module.scss
@@ -15,25 +15,4 @@
     gap: 15px;
   }
 
-  a {
-    color: black;
-    text-align: center;
-    padding: 8px;
-    text-decoration: none;
-    font-size: 18px;
-    line-height: 25px;
-    border-radius: 4px;
-  }
-
-  a.logo {
-    display: flex;
-    align-items: center;
-    padding: 0;
-  }
-
-  a.logo img {
-    padding: 0;
-    max-width: 200px;
-    width: 40vw;
-  }
 }

--- a/src/components/Layout/Layout.jsx
+++ b/src/components/Layout/Layout.jsx
@@ -98,7 +98,6 @@ const Layout = () => {
               />
               <Button
                 variant="contained"
-                startIcon={<AddIcon />}
                 onClick={onCreateButtonClickHandler}
                 sx={{
                   bgcolor: "var(--secondary-color)",
@@ -106,11 +105,13 @@ const Layout = () => {
                   textTransform: "none",
                   fontWeight: "bold",
                   borderRadius: "8px",
-                  px: 3,
-                  whiteSpace: "nowrap",
+                  minWidth: "auto",
+                  width: "45px",
+                  height: "45px",
+                  padding: 0,
                 }}
               >
-                Nuovo Terreno
+                <AddIcon />
               </Button>
             </div>
             <MobileMenu

--- a/src/components/Layout/Layout.module.scss
+++ b/src/components/Layout/Layout.module.scss
@@ -43,7 +43,7 @@
 .headerContent {
   display: flex;
   width: 100%;
-  justify-content: space-between;
+  justify-content: flex-end;
   align-items: center;
   gap: 20px;
 }
@@ -52,6 +52,7 @@
   display: flex;
   align-items: center;
   gap: 20px;
+  justify-content: flex-end;
   flex-grow: 1;
 
   @media (max-width: 600px) {
@@ -60,8 +61,8 @@
 }
 
 .headerSearch {
-  flex-grow: 1;
-  max-width: 600px;
+  width: 100%;
+  max-width: 400px;
 }
 
 .layoutContent {

--- a/src/components/Side/Side.jsx
+++ b/src/components/Side/Side.jsx
@@ -20,8 +20,11 @@ const Side = ({ onSelect, active }) => {
   return (
     <div className={classes.sideContainer}>
       <div className={classes.sideHeader}>
-        <div className={classes.riepilogoTitle}>Riepilogo</div>
-        <div className={classes.riepilogoSubtitle}>Statistiche generali</div>
+        <img
+          src="/logolabel.png"
+          alt="Agricola logo"
+          className={classes.logoSidebar}
+        />
       </div>
 
       <div className={classes.statsContainer}>

--- a/src/components/Side/Side.module.css
+++ b/src/components/Side/Side.module.css
@@ -10,18 +10,14 @@
 
 .sideHeader {
   margin-bottom: 25px;
+  display: flex;
+  justify-content: center;
 }
 
-.riepilogoTitle {
-  font-size: 1.2rem;
-  font-weight: 700;
-  color: var(--primary-color-dark);
-  margin-bottom: 4px;
-}
-
-.riepilogoSubtitle {
-  font-size: 0.85rem;
-  color: #8c96a3;
+.logoSidebar {
+  max-width: 100%;
+  height: auto;
+  max-height: 50px;
 }
 
 .statsContainer {


### PR DESCRIPTION
This PR improves the Agricola app's layout by:
1. Moving the logo from the header to the sidebar, replacing the static 'Riepilogo' section.
2. Aligning the search bar and the 'Nuovo Terreno' button to the right in the header.
3. Simplifying the 'Nuovo Terreno' button to show only the '+' icon, improving visual cleanliness on the header.
4. Updating styles to ensure proper spacing and responsiveness for these changes.

---
*PR created automatically by Jules for task [16225828746205740447](https://jules.google.com/task/16225828746205740447) started by @adekro*