### PR TITLE
Move delete farmland button under map configuration

### DIFF
--- a/src/components/FarmlandScreen/FarmlandScreen.jsx
+++ b/src/components/FarmlandScreen/FarmlandScreen.jsx
@@ -306,13 +306,13 @@ const FarmlandScreen = (props) => {
                 </>
               )}
             </Box>
+            {farmland && (
+              <div className={classes.detailsWrapper}>
+                <Button onClick={deleteHandler}>Delete farmland</Button>
+              </div>
+            )}
           </div>
         </div>
-        {farmland && (
-          <div className={classes.detailsWrapper}>
-            <Button onClick={deleteHandler}>Delete farmland</Button>
-          </div>
-        )}
       </div>
 
       <Snackbar

--- a/src/components/FarmlandScreen/FarmlandScreen.module.scss
+++ b/src/components/FarmlandScreen/FarmlandScreen.module.scss
@@ -71,3 +71,9 @@
   background-color: #f9f9f9;
   border-radius: 8px;
 }
+
+.detailsWrapper {
+  margin-top: 20px;
+  display: flex;
+  justify-content: center;
+}


### PR DESCRIPTION
Moved the "Delete farmland" button to be vertically aligned under the "Map Configuration" section in the `FarmlandScreen` component. This was achieved by moving the button's JSX block into the `FormSide` container and adding corresponding styles in the SCSS module.

---
*PR created automatically by Jules for task [8138198714913420656](https://jules.google.com/task/8138198714913420656) started by @adekro*