### PR TITLE
Fix white screen crash in Farmland screen

### DIFF
--- a/src/components/FarmlandScreen/FarmlandScreen.jsx
+++ b/src/components/FarmlandScreen/FarmlandScreen.jsx
@@ -12,6 +12,18 @@ import {
   Slider,
   Box,
   Divider,
+  TableContainer,
+  Paper,
+  Table,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableBody,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Stack,
 } from "@mui/material";
 import FullScreenDialog from "../UI/FullScreenDialog/FullScreenDialog";
 import { useState, useCallback } from "react";


### PR DESCRIPTION
Fixed a runtime crash in the Farmland screen that caused a "white screen" for users. The issue was due to several Material UI components (`TableContainer`, `Paper`, `Table`, `TableHead`, `TableRow`, `TableCell`, `TableBody`, `Dialog`, `DialogTitle`, `DialogContent`, `DialogActions`, and `Stack`) being used in the JSX but not imported at the top of the file. Adding these missing imports resolves the `ReferenceError` and allows the component to render correctly.

---
*PR created automatically by Jules for task [3398575360349783554](https://jules.google.com/task/3398575360349783554) started by @adekro*