### PR TITLE
Add status filter to Phytosanitary Products screen

### DIFF
--- a/src/components/FitosanitariScreen/FitosanitariScreen.jsx
+++ b/src/components/FitosanitariScreen/FitosanitariScreen.jsx
@@ -13,6 +13,10 @@ import {
   Box,
   CircularProgress,
   Chip,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
 } from "@mui/material";
 import {
   openDB,
@@ -24,6 +28,7 @@ import {
 const FitosanitariScreen = () => {
   const [products, setProducts] = useState([]);
   const [filter, setFilter] = useState("");
+  const [statusFilter, setStatusFilter] = useState("Tutti");
   const [loading, setLoading] = useState(false);
   const [lastFile, setLastFile] = useState(null);
 
@@ -72,12 +77,25 @@ const FitosanitariScreen = () => {
     setLoading(false);
   };
 
-  const filteredProducts = products.filter((p) =>
-    Object.values(p).some(
+  const statuses = [
+    "Tutti",
+    ...new Set(
+      products
+        .map((p) => p.stato_amministrativo)
+        .filter(Boolean)
+        .sort(),
+    ),
+  ];
+
+  const filteredProducts = products.filter((p) => {
+    const matchesFilter = Object.values(p).some(
       (val) =>
         val && val.toString().toLowerCase().includes(filter.toLowerCase()),
-    ),
-  );
+    );
+    const matchesStatus =
+      statusFilter === "Tutti" || p.stato_amministrativo === statusFilter;
+    return matchesFilter && matchesStatus;
+  });
 
   return (
     <Box sx={{ p: 3, display: "flex", flexDirection: "column", gap: 2 }}>
@@ -100,13 +118,31 @@ const FitosanitariScreen = () => {
         )}
       </Box>
 
-      <TextField
-        fullWidth
-        variant="outlined"
-        placeholder="Cerca prodotti..."
-        value={filter}
-        onChange={(e) => setFilter(e.target.value)}
-      />
+      <Box sx={{ display: "flex", gap: 2, flexWrap: "wrap" }}>
+        <TextField
+          sx={{ flexGrow: 1 }}
+          variant="outlined"
+          placeholder="Cerca prodotti..."
+          value={filter}
+          onChange={(e) => setFilter(e.target.value)}
+        />
+        <FormControl sx={{ minWidth: 200 }}>
+          <InputLabel id="status-filter-label">Stato</InputLabel>
+          <Select
+            labelId="status-filter-label"
+            id="status-filter"
+            value={statusFilter}
+            label="Stato"
+            onChange={(e) => setStatusFilter(e.target.value)}
+          >
+            {statuses.map((status) => (
+              <MenuItem key={status} value={status}>
+                {status}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+      </Box>
 
       <TableContainer
         component={Paper}

--- a/src/components/FitosanitariScreen/FitosanitariScreen.test.jsx
+++ b/src/components/FitosanitariScreen/FitosanitariScreen.test.jsx
@@ -1,0 +1,79 @@
+import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
+import FitosanitariScreen from "./FitosanitariScreen";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import React from "react";
+import * as indexedDB from "../../lib/indexedDB";
+
+vi.mock("../../lib/indexedDB", () => ({
+  getProducts: vi.fn(),
+  getLastUpdated: vi.fn(),
+  saveProducts: vi.fn(),
+  openDB: vi.fn(),
+}));
+
+const mockProducts = [
+  {
+    denominazione_prodotto: "Product A",
+    stato_amministrativo: "In commercio",
+    sostanze_attive: "Substance X",
+    ragione_sociale: "Company 1",
+    num_registrazione: "123",
+    data_registrazione: "2023-01-01",
+  },
+  {
+    denominazione_prodotto: "Product B",
+    stato_amministrativo: "Revocato",
+    sostanze_attive: "Substance Y",
+    ragione_sociale: "Company 2",
+    num_registrazione: "456",
+    data_registrazione: "2023-02-02",
+  },
+];
+
+describe("FitosanitariScreen Component", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    indexedDB.getProducts.mockResolvedValue(mockProducts);
+    indexedDB.getLastUpdated.mockResolvedValue({ value: "test.json" });
+  });
+
+  it("renders products from indexedDB", async () => {
+    render(<FitosanitariScreen />);
+
+    expect(await screen.findByText("Product A")).toBeDefined();
+    expect(await screen.findByText("Product B")).toBeDefined();
+    expect(screen.getByText("File: test.json")).toBeDefined();
+  });
+
+  it("filters products by text search", async () => {
+    render(<FitosanitariScreen />);
+
+    await screen.findByText("Product A");
+
+    const searchInput = screen.getByPlaceholderText("Cerca prodotti...");
+    fireEvent.change(searchInput, { target: { value: "Product A" } });
+
+    expect(screen.queryByText("Product A")).not.toBeNull();
+    expect(screen.queryByText("Product B")).toBeNull();
+  });
+
+  it("filters products by status", async () => {
+    render(<FitosanitariScreen />);
+
+    await screen.findByText("Product A");
+
+    // Open the status select
+    const statusSelect = screen.getByLabelText("Stato");
+    fireEvent.mouseDown(statusSelect);
+
+    // The options are rendered in a portal, so we look for them in the document
+    const listbox = await screen.findByRole("listbox");
+    const option = within(listbox).getByText("Revocato");
+    fireEvent.click(option);
+
+    await waitFor(() => {
+        expect(screen.queryByText("Product A")).toBeNull();
+        expect(screen.queryByText("Product B")).not.toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
This PR adds a new filter to the Phytosanitary Products (Prodotti Fitosanitari) screen, allowing users to filter products by their administrative status (e.g., "In commercio", "Revocato").

Key changes:
- Added a `Select` dropdown in `FitosanitariScreen.jsx` to choose a status.
- The list of statuses is dynamically generated from the available products.
- The product list now filters based on both the text search and the selected status.
- Added comprehensive unit tests in `src/components/FitosanitariScreen/FitosanitariScreen.test.jsx`.

---
*PR created automatically by Jules for task [15127159472868254272](https://jules.google.com/task/15127159472868254272) started by @adekro*