### PR TITLE
Fix Farmland mobile layout overlap

### DIFF
--- a/src/components/FarmlandScreen/FarmlandScreen.module.scss
+++ b/src/components/FarmlandScreen/FarmlandScreen.module.scss
@@ -49,6 +49,11 @@
       height: 400px;
       min-height: 300px;
 
+      @media (max-width: 900px) {
+        height: 400px;
+        min-height: 300px;
+      }
+
       @media (min-width: 901px) {
         flex: 1;
         height: 600px;
@@ -63,6 +68,11 @@
   flex-direction: column;
   padding-left: 20px;
   overflow-y: auto;
+
+  @media (max-width: 900px) {
+    padding-left: 0;
+    width: 100%;
+  }
 }
 
 .MapConfig {

--- a/src/components/WorldMap/WordMap.module.css
+++ b/src/components/WorldMap/WordMap.module.css
@@ -1,13 +1,22 @@
 .genMap {
   width: 100%;
-  height: 80vh;
+  height: 100%;
   display: flex;
   justify-content: center;
 }
 
 .map {
   position: relative;
-  width: 50vw;
+  width: 100%;
+  max-width: 600px;
+  height: 100%;
   border-radius: 10px;
   overflow: hidden;
+}
+
+@media (min-width: 901px) {
+  .map {
+    width: 50vw;
+    max-width: none;
+  }
 }


### PR DESCRIPTION
This change reorganizes the Farmland screen layout on mobile devices to prevent form inputs from overlapping with the map. 

Key changes:
- In `src/components/WorldMap/WordMap.module.css`, the map container (`.genMap`) now uses `height: 100%` instead of `80vh`, allowing its parent to control the height.
- The `.map` element itself is now responsive, taking up `100%` width (up to `600px`) on mobile and `50vw` on desktop.
- In `src/components/FarmlandScreen/FarmlandScreen.module.scss`, the form side (`.FormSide`) no longer has left padding on mobile, and the map wrapper (`.MapWrapper`) maintains a dedicated height, ensuring the vertical stacking is correct and usable.

---
*PR created automatically by Jules for task [9586874499942557585](https://jules.google.com/task/9586874499942557585) started by @adekro*